### PR TITLE
Fix #11107 - don't prefetch preloaded modules

### DIFF
--- a/packages/next/client/route-loader.ts
+++ b/packages/next/client/route-loader.ts
@@ -94,7 +94,10 @@ function prefetchViaDom(
   link?: HTMLLinkElement
 ): Promise<any> {
   return new Promise((res, rej) => {
-    if (document.querySelector(`link[rel="prefetch"][href^="${href}"]`)) {
+    const selector = `
+      link[rel="prefetch"][href^="${href}"],
+      link[rel="preload"][href^="${href}"]`
+    if (document.querySelector(selector)) {
       return res()
     }
 


### PR DESCRIPTION
This PR proposes a fix for https://github.com/vercel/next.js/issues/11107 (JS modules are loaded twice). A more detailed explanation of the investigation that led to this PR can be found in the issue's comments (https://github.com/vercel/next.js/issues/11107#issuecomment-791780168).

## Replicability

In my own project using `"next": "^10.0.1"` the issue is reproduced.
In the issue's comments, a developer reported a replication using `"^10.0.7"`.
The issue is reproduced on https://nextjs.org/ by looking at the network tab, filtering by `.js` files and looking for pairs of identical calls with one originating from initial HTML (`preload`)  and another one from a script (adding `prefetch` link to DOM).

## Some information about the fix

- Both `preload` and `prefetch` values for `<link rel="x">` behave similarly, with the difference being in network priority level (preload is high priority, prefetch is low priority).

- Next.js uses `<link rel="preload">` in its initial HTML but then *only* uses `<link rel="prefetch">` for the rest of the lifetime of the page. 

- However, when Next.js detects that a script should be requested in advance, it only checks for matching `<link rel="prefetch">` and not `<link rel="preload">` (which have higher priority and are present earlier in the DOM, thus have a greater likelihood of being already loaded). 

This PR aims to fix that oversight.

## Potential issues (none AFAIK)

As far as I can tell by looking through the codebase, **there is no downside** not to add a `prefetch` when a `preload` is already in the DOM. No other script looks for a `<link>` based on its `rel` attribute.